### PR TITLE
Allow for redirection when query string is present

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,13 +8,25 @@
 chrome.webRequest.onBeforeRequest.addListener(
   // Checking if it is not redirecting to all steps.
   function(details) {
+    var queryCharacter; // Either '?' or '&' depending on the presence of a query string
+    
     if(details.url.indexOf("ALLSTEPS") == -1) {
-      // Redirecting it to all steps page.
-      return {redirectUrl: details.url+"?ALLSTEPS"};
+      // Not in all steps view yet
+      if(details.url.indexOf("?") == -1) {
+        // No query string present yet
+        queryCharacter = "?";
+      }
+      else {
+        // Query already present, add to end with ampersand
+        queryCharacter = "&";
+      }
+      
+      // Redirect to all steps page
+      return {redirectUrl: details.url+queryCharacter+"ALLSTEPS"};
     }
   },
-  // Applies to following url patterns
-  {urls: ["*://www.instructables.com/id/*/"]},
+  // Applies to following url patterns - can have a query string following
+  {urls: ["*://www.instructables.com/id/*"]},
   // In request blocking mode
   ["blocking"]
 );

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "manifest_version": 2,
   "name": "Instructables Default All Steps",
   "description": "Sets all instructables default to View All Steps [me@nishantarora.in]",
-  "version": "0.1",
+  "version": "0.2",
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "*://www.instructables.com/id/*/"
+    "*://www.instructables.com/id/*"
   ],
   "background": {"scripts": ["background.js"]}
 }


### PR DESCRIPTION
Currently, this extension does not redirect if a query string is present.  If a link is clicked from their email newsletter, which contains utm_* campaign information, this extension will not redirect.

The changes submitted here extend the URL patterns that this extension applies, such that a URL with a query string is accepted.  Furthermore, a check is now performed that evaluates the presence of a question mark (indicating the beginning of the query string), and either adds "?ALLSTEPS" or "&ALLSTEPS" depending on if a query string is already present.

* Change version to 0.2
* Change URL match pattern in manifest
* Change URL match pattern in background.js
* Add extra conditional in background.js checking if a query string is already present